### PR TITLE
[FEAT] - Added support for Bot starting the conversation

### DIFF
--- a/PVATestFramework/PVATestFramework/Helpers/Constants.cs
+++ b/PVATestFramework/PVATestFramework/Helpers/Constants.cs
@@ -7,6 +7,12 @@ namespace PVATestFramework.Console.Helpers
     {
         public const string Message = "message";
         public const string Trace = "trace";
+        public const string Event = "event";
+    }
+
+    public static class ActivityEventNames
+    {
+        public const string StartConversation = "startConversation";
     }
 
     public static class RoleTypes

--- a/PVATestFramework/PVATestFramework/Helpers/DirectLine/DirectLineClient.cs
+++ b/PVATestFramework/PVATestFramework/Helpers/DirectLine/DirectLineClient.cs
@@ -42,10 +42,11 @@ namespace PVATestFramework.Console.Helpers.DirectLine
                 {
                     Type = activity.Type,
                     From = _channelAccount,
-                    Text = activity.Text
+                    Text = activity.Text,
+                    Name = activity.Name
                 };
 
-                await _directLineClient.Conversations.PostActivityAsync(_conversation.ConversationId, activityPost, cancellationToken).ConfigureAwait(false);
+                await _directLineClient.Conversations.PostActivityAsync(_conversation?.ConversationId, activityPost, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -61,9 +62,23 @@ namespace PVATestFramework.Console.Helpers.DirectLine
 
             try
             {
+                if (_conversation == null)
+                {
+                    await StartConversationAsync().ConfigureAwait(false);
+                    
+                    //Force the greeting message to be sent by the Bot
+                    var sendActivity = new Activity
+                    {
+                        Type = ActivityTypes.Event,
+                        Name = ActivityEventNames.StartConversation
+                    };
+
+                    await SendActivityAsync(sendActivity, cancellationToken).ConfigureAwait(false);
+                }
+
                 do
                 {
-                    response = await _directLineClient.Conversations.GetActivitiesAsync(_conversation.ConversationId, _watermark);
+                    response = await _directLineClient.Conversations.GetActivitiesAsync(_conversation?.ConversationId, _watermark);
                     if (response == null)
                     {
                         // Response can be null if directLineClient token expires


### PR DESCRIPTION
### Describe the PR
Added support to the tool so the bot can start the conversation without failing. Originally, the conversation was started only by the user, but now it can be triggered by a greeting message sent by the bot.

### Changes included in the PR
- Trigger the StartConversation event
- Handle the message sent by the bot